### PR TITLE
A little extra logging detail.

### DIFF
--- a/Data/Scripts/DefenseShields/SupportClasses/StaticUtils.cs
+++ b/Data/Scripts/DefenseShields/SupportClasses/StaticUtils.cs
@@ -584,7 +584,7 @@ namespace DefenseShields.Support
                         if (Session.Instance.AmmoCollection.ContainsKey(shot.MissileModelName)) continue;
                         Session.Instance.AmmoCollection.Add(shot.MissileModelName, new AmmoInfo(shot.IsExplosive, shot.MissileExplosionDamage, shot.MissileExplosionRadius, shot.DesiredSpeed, shot.MissileMass, shot.BackkickForce));
                     }
-                    catch (Exception ex) { Log.Line($"Exception in GetAmmoDefinitions: {def.DisplayNameString} : {ex}"); }
+                    catch (Exception ex) { Log.Line($"Exception in GetAmmoDefinitions: {def.DisplayNameString} in {def.Context.ModName} ({def.Context.ModId}) : {ex}"); }
                 }
                 if (Session.Enforced.Debug == 3) Log.Line("Definitions: Session");
             }

--- a/Data/Scripts/DefenseShields/SupportClasses/StaticUtils.cs
+++ b/Data/Scripts/DefenseShields/SupportClasses/StaticUtils.cs
@@ -575,11 +575,16 @@ namespace DefenseShields.Support
                 {
                     if (!(def is MyAmmoMagazineDefinition)) continue;
                     var ammoDef = def as MyAmmoMagazineDefinition;
-                    var ammo = MyDefinitionManager.Static.GetAmmoDefinition(ammoDef.AmmoDefinitionId);
-                    if (!(ammo is MyMissileAmmoDefinition)) continue;
-                    var shot = ammo as MyMissileAmmoDefinition;
-                    if (Session.Instance.AmmoCollection.ContainsKey(shot.MissileModelName)) continue;
-                    Session.Instance.AmmoCollection.Add(shot.MissileModelName, new AmmoInfo(shot.IsExplosive, shot.MissileExplosionDamage, shot.MissileExplosionRadius, shot.DesiredSpeed, shot.MissileMass, shot.BackkickForce));
+                    try
+                    {
+                        var ammo = MyDefinitionManager.Static.GetAmmoDefinition(ammoDef.AmmoDefinitionId);
+                    
+                        if (!(ammo is MyMissileAmmoDefinition)) continue;
+                        var shot = ammo as MyMissileAmmoDefinition;
+                        if (Session.Instance.AmmoCollection.ContainsKey(shot.MissileModelName)) continue;
+                        Session.Instance.AmmoCollection.Add(shot.MissileModelName, new AmmoInfo(shot.IsExplosive, shot.MissileExplosionDamage, shot.MissileExplosionRadius, shot.DesiredSpeed, shot.MissileMass, shot.BackkickForce));
+                    }
+                    catch (Exception ex) { Log.Line($"Exception in GetAmmoDefinitions: {def.DisplayNameString} : {ex}"); }
                 }
                 if (Session.Enforced.Debug == 3) Log.Line("Definitions: Session");
             }


### PR DESCRIPTION
Not sure if this code is even important any more, but appeared in the logs as a throw without much information. Added a bit more to that particular failure to make debugging other mods easier, and localised the failure to a single place by not terminating the whole loop.
Even if this code isn't used any more, it might expose definition bugs that may cause issues elsewhere, such as in weaponcore.